### PR TITLE
Fix round2 function for negative values

### DIFF
--- a/cmd/observer/loop.go
+++ b/cmd/observer/loop.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"math"
 	"strings"
 
 	"github.com/szymon3/bambu-middleman/auditlog"
@@ -212,7 +213,7 @@ func parseStatusString(s gcode.ParseStatus) string {
 }
 
 func round2(f float64) float64 {
-	return float64(int(f*100+0.5)) / 100
+	return math.Round(f*100) / 100
 }
 
 func addUsage(a, b gcode.FilamentUsage) gcode.FilamentUsage {


### PR DESCRIPTION
Closes #1

Replace the hand-rolled `add 0.5 and truncate` trick with `math.Round`, which handles negative values correctly.

`round2(-0.3)` previously produced `-0.29`; now correctly returns `-0.30`.