### PR TITLE
Export addUsage from gcode package to eliminate duplication

### DIFF
--- a/cmd/observer/loop.go
+++ b/cmd/observer/loop.go
@@ -115,7 +115,7 @@ func (o *Observer) logResult(ctx context.Context, log *slog.Logger, result *gcod
 		layersPrinted = len(result.Layers)
 	}
 
-	total := addUsage(result.StartupUsage, layerUsage)
+	total := gcode.AddUsage(result.StartupUsage, layerUsage)
 
 	statusStr := parseStatusString(result.Status)
 
@@ -215,10 +215,3 @@ func round2(f float64) float64 {
 	return float64(int(f*100+0.5)) / 100
 }
 
-func addUsage(a, b gcode.FilamentUsage) gcode.FilamentUsage {
-	return gcode.FilamentUsage{
-		LengthMM:  a.LengthMM + b.LengthMM,
-		VolumeCM3: a.VolumeCM3 + b.VolumeCM3,
-		WeightG:   a.WeightG + b.WeightG,
-	}
-}

--- a/gcode/types.go
+++ b/gcode/types.go
@@ -44,7 +44,7 @@ func (p *PrintFile) ComputedUsage(upToLayer int) (FilamentUsage, error) {
 	}
 	var total FilamentUsage
 	for i := 0; i < end; i++ {
-		total = addUsage(total, p.Layers[i].Usage)
+		total = AddUsage(total, p.Layers[i].Usage)
 	}
 	return total, nil
 }
@@ -53,10 +53,11 @@ func (p *PrintFile) ComputedUsage(upToLayer int) (FilamentUsage, error) {
 // StartupUsage plus all layer usage.
 func (p *PrintFile) TotalUsage() FilamentUsage {
 	layerTotal, _ := p.ComputedUsage(0)
-	return addUsage(p.StartupUsage, layerTotal)
+	return AddUsage(p.StartupUsage, layerTotal)
 }
 
-func addUsage(a, b FilamentUsage) FilamentUsage {
+// AddUsage returns the element-wise sum of two FilamentUsage values.
+func AddUsage(a, b FilamentUsage) FilamentUsage {
 	return FilamentUsage{
 		LengthMM:  a.LengthMM + b.LengthMM,
 		VolumeCM3: a.VolumeCM3 + b.VolumeCM3,


### PR DESCRIPTION
Closes #2

- Rename `addUsage` → `AddUsage` in `gcode/types.go` (exported)
- Update the two internal callers in `TotalUsage` and `ComputedUsage`
- Remove the identical copy from `cmd/observer/loop.go`, replacing its call site with `gcode.AddUsage`