### PR TITLE
Remove unused ParseFailed constant

### DIFF
--- a/cmd/observer/loop.go
+++ b/cmd/observer/loop.go
@@ -207,7 +207,7 @@ func parseStatusString(s gcode.ParseStatus) string {
 	case gcode.ParsePartial:
 		return "PARTIAL"
 	default:
-		return "FAILED"
+		return "UNKNOWN"
 	}
 }
 

--- a/gcode/types.go
+++ b/gcode/types.go
@@ -11,11 +11,6 @@ type ParseStatus int
 const (
 	ParseOK      ParseStatus = iota // all sections parsed successfully
 	ParsePartial                    // file parsed but some sections missing or malformed
-	// ParseFailed is reserved/defensive. The parser currently returns
-	// (nil, error) instead of a *PrintFile with this status; it exists for
-	// forward compatibility with callers that may receive a partially
-	// constructed result from future error paths.
-	ParseFailed
 )
 
 // PrintFile holds all data extracted from a parsed gcode file.


### PR DESCRIPTION
Closes #4

- Remove `ParseFailed` from the `ParseStatus` const block in `gcode/types.go`; the parser never assigns it (fatal errors return `(nil, error)`)
- Update `parseStatusString` default branch from `"FAILED"` → `"UNKNOWN"` since the only remaining values are `ParseOK` and `ParsePartial`