### PR TITLE
Extract shared MQTT client options to eliminate duplication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@
 .env
 
 # Compiled binaries
-mqttdump
+/mqttdump
 
 # MQTT dump data
 *.jsonl

--- a/cmd/mqttdump/main.go
+++ b/cmd/mqttdump/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -41,17 +40,8 @@ func main() {
 	var count int
 	connLost := make(chan struct{}, 1)
 
-	opts := mqtt.NewClientOptions().
-		AddBroker(fmt.Sprintf("tls://%s", cfg.MQTTBrokerAddr())).
+	opts := printer.NewMQTTClientOptions(cfg).
 		SetClientID("bambu-mqttdump").
-		SetUsername("bblp").
-		SetPassword(cfg.AccessCode).
-		SetKeepAlive(30 * time.Second).
-		SetConnectTimeout(10 * time.Second).
-		SetAutoReconnect(false).
-		SetTLSConfig(&tls.Config{
-			InsecureSkipVerify: true, //nolint:gosec // printer uses a self-signed certificate
-		}).
 		SetConnectionLostHandler(func(_ mqtt.Client, err error) {
 			fmt.Fprintf(os.Stderr, "Connection lost: %v\n", err)
 			select {

--- a/printer/mqtt.go
+++ b/printer/mqtt.go
@@ -36,6 +36,24 @@ type MQTTClient struct {
 	lastLayerNum    int    // last layer_num received (1-indexed); 0 means unknown
 }
 
+// NewMQTTClientOptions returns a base *mqtt.ClientOptions configured with the
+// shared settings (broker, credentials, TLS, keepalive, timeouts, no
+// auto-reconnect). Callers should chain SetClientID and
+// SetConnectionLostHandler before constructing the client.
+func NewMQTTClientOptions(cfg Config) *mqtt.ClientOptions {
+	return mqtt.NewClientOptions().
+		AddBroker(fmt.Sprintf("tls://%s", cfg.MQTTBrokerAddr())).
+		SetClientID("bambu-middleman").
+		SetUsername("bblp").
+		SetPassword(cfg.AccessCode).
+		SetKeepAlive(keepAlive).
+		SetConnectTimeout(connectTimeout).
+		SetAutoReconnect(false). // callers manage reconnect themselves
+		SetTLSConfig(&tls.Config{
+			InsecureSkipVerify: true, //nolint:gosec // printer uses a self-signed certificate
+		})
+}
+
 // NewMQTTClient creates a new MQTTClient. Call Run to start the connection loop.
 func NewMQTTClient(cfg Config, log *slog.Logger) *MQTTClient {
 	return &MQTTClient{
@@ -110,17 +128,7 @@ func (c *MQTTClient) connect(ctx context.Context) (bool, error) {
 
 	connLost := make(chan error, 1)
 
-	opts := mqtt.NewClientOptions().
-		AddBroker(fmt.Sprintf("tls://%s", c.cfg.MQTTBrokerAddr())).
-		SetClientID("bambu-middleman").
-		SetUsername("bblp").
-		SetPassword(c.cfg.AccessCode).
-		SetKeepAlive(keepAlive).
-		SetConnectTimeout(connectTimeout).
-		SetAutoReconnect(false). // we manage reconnect ourselves
-		SetTLSConfig(&tls.Config{
-			InsecureSkipVerify: true, //nolint:gosec // printer uses a self-signed certificate
-		}).
+	opts := NewMQTTClientOptions(c.cfg).
 		SetConnectionLostHandler(func(_ mqtt.Client, err error) {
 			c.log.Warn("mqtt connection lost", "err", err)
 			select {


### PR DESCRIPTION
Closes #5

Add `printer.NewMQTTClientOptions(cfg)` that centralises the shared connection settings (broker address, credentials, TLS, keepalive, connect timeout, auto-reconnect). Both `mqtt.go` and `mqttdump/main.go` chain `.SetClientID` and `.SetConnectionLostHandler` on top. Connection parameters now only need to change in one place.

Also fixes `.gitignore`: anchors `/mqttdump` to the repo root so it no longer accidentally ignores the `cmd/mqttdump` source directory.