### PR TITLE
Reject negative filament diameter in convertToFilamentUsage

### DIFF
--- a/gcode/parser.go
+++ b/gcode/parser.go
@@ -432,7 +432,7 @@ func parseFooterLine(line string, f *FooterSummary) {
 }
 
 func convertToFilamentUsage(lengthMM, diameter, density float64) FilamentUsage {
-	if diameter == 0 {
+	if diameter <= 0 {
 		return FilamentUsage{LengthMM: lengthMM}
 	}
 	radius := diameter / 2


### PR DESCRIPTION
Closes #6

Change `diameter == 0` to `diameter <= 0` in `convertToFilamentUsage`. A negative diameter from a malformed header passes the zero-check but produces silently wrong results (squaring makes volume positive). This aligns the guard with the `density > 0` pattern already used directly below.