### PR TITLE
feat: add shell install script for Linux deployment

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,197 @@
+#!/usr/bin/env bash
+# install.sh — install or upgrade bambu-observer on a Linux host.
+#
+# Usage:
+#   sudo bash install.sh            # first-time install
+#   sudo bash install.sh --upgrade  # swap binary, leave config untouched
+#
+# Requires: curl, sha256sum, useradd, systemctl (standard on most Linux distros).
+set -euo pipefail
+
+REPO="szymon3/bambu-middleman"
+BINARY_NAME="bambu-observer"
+INSTALL_BIN="/usr/local/bin/bambu-observer"
+CONF_DIR="/etc/bambu-observer"
+UNIT_PATH="/etc/systemd/system/bambu-observer.service"
+SERVICE_USER="bambu-observer"
+UPGRADE=false
+
+# ── argument parsing ──────────────────────────────────────────────────────────
+
+for arg in "$@"; do
+  case "$arg" in
+    --upgrade) UPGRADE=true ;;
+    *) echo "Unknown argument: $arg" >&2; exit 1 ;;
+  esac
+done
+
+# ── helpers ───────────────────────────────────────────────────────────────────
+
+die()  { echo "ERROR: $*" >&2; exit 1; }
+info() { printf '\033[1;32m==>\033[0m %s\n' "$*"; }
+
+[[ $EUID -eq 0 ]] || die "This script must be run as root (try: sudo bash install.sh $*)"
+
+for cmd in curl sha256sum; do
+  command -v "$cmd" &>/dev/null || die "Required tool not found: $cmd"
+done
+
+if ! $UPGRADE; then
+  for cmd in useradd systemctl; do
+    command -v "$cmd" &>/dev/null || die "Required tool not found: $cmd"
+  done
+fi
+
+detect_arch() {
+  case "$(uname -m)" in
+    x86_64)  echo "amd64" ;;
+    aarch64) echo "arm64" ;;
+    *) die "Unsupported architecture: $(uname -m). Only amd64 and arm64 are supported." ;;
+  esac
+}
+
+fetch_latest_tag() {
+  curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" \
+    | grep '"tag_name"' \
+    | head -1 \
+    | sed 's/.*"tag_name": *"\([^"]*\)".*/\1/'
+}
+
+# ── resolve release ───────────────────────────────────────────────────────────
+
+ARCH=$(detect_arch)
+ASSET="${BINARY_NAME}_linux_${ARCH}"
+
+info "Fetching latest release tag..."
+TAG=$(fetch_latest_tag)
+[[ -n "$TAG" ]] || die "Could not determine latest release tag from GitHub API."
+info "Latest release: $TAG"
+
+# ── download and verify ───────────────────────────────────────────────────────
+
+WORKDIR=$(mktemp -d)
+trap 'rm -rf "$WORKDIR"' EXIT
+
+BASE_URL="https://github.com/${REPO}/releases/download/${TAG}"
+
+info "Downloading ${ASSET}..."
+curl -fSL --progress-bar "${BASE_URL}/${ASSET}" -o "${WORKDIR}/${ASSET}"
+curl -fsSL "${BASE_URL}/sha256sums.txt" -o "${WORKDIR}/sha256sums.txt"
+
+info "Verifying checksum..."
+(cd "$WORKDIR" && grep "  ${ASSET}$" sha256sums.txt | sha256sum -c -)
+info "Checksum OK."
+
+chmod +x "${WORKDIR}/${ASSET}"
+
+# ── upgrade path ──────────────────────────────────────────────────────────────
+
+if $UPGRADE; then
+  info "Stopping service..."
+  systemctl stop bambu-observer || true
+
+  info "Installing new binary..."
+  install -m 755 "${WORKDIR}/${ASSET}" "${INSTALL_BIN}"
+
+  info "Starting service..."
+  systemctl start bambu-observer
+
+  info "Upgrade complete. Configuration in ${CONF_DIR}/env was not modified."
+  exit 0
+fi
+
+# ── first-time install ────────────────────────────────────────────────────────
+
+# System user
+if id -u "$SERVICE_USER" &>/dev/null; then
+  info "System user '${SERVICE_USER}' already exists."
+else
+  info "Creating system user '${SERVICE_USER}'..."
+  useradd --system --no-create-home --shell /usr/sbin/nologin "$SERVICE_USER"
+fi
+
+# Binary
+info "Installing binary to ${INSTALL_BIN}..."
+install -m 755 "${WORKDIR}/${ASSET}" "${INSTALL_BIN}"
+
+# Config directory
+install -d -m 755 "$CONF_DIR"
+
+# env.example — always write so it stays current
+info "Writing ${CONF_DIR}/env.example..."
+cat > "${CONF_DIR}/env.example" <<'EOF'
+# /etc/bambu-observer/env
+# Bambu Observer configuration.
+# Restart the service after any change: systemctl restart bambu-observer
+
+# ── Required ──────────────────────────────────────────────────────────────────
+
+# Local IP address of the printer
+PRINTER_IP=192.168.1.100
+
+# Printer serial number (on the printer label or in the Bambu app)
+PRINTER_SERIAL=01P00A000000001
+
+# 8-digit access code shown on the printer screen (Settings → LAN Mode)
+PRINTER_ACCESS_CODE=12345678
+
+# ── Optional ──────────────────────────────────────────────────────────────────
+
+# Log verbosity. DEBUG for verbose output; default is INFO.
+#LOG_LEVEL=INFO
+
+# Base URL of a Spoolman instance — enables automatic spool-usage updates.
+#SPOOLMAN_URL=http://192.168.1.10:7912
+
+# Ordered list of spool ID sources tried left-to-right.
+# "api" = active spool set via the web UI; "notes" = spoolman#N tag in filament notes.
+# Default: api,notes
+#SPOOLMAN_SOURCE=api,notes
+
+# Address to bind the built-in HTTP server — enables active spool tracking.
+#WEBUI_ADDR=:8080
+
+# Externally reachable base URL of the HTTP server — baked into generated QR codes.
+#WEBUI_BASE_URL=http://192.168.1.10:8080
+
+# Filesystem path for the audit log SQLite database.
+#AUDIT_DB_PATH=/var/lib/bambu-observer/audit.db
+EOF
+
+# env — only create from template if it doesn't exist yet (treat as conffile)
+if [[ -f "${CONF_DIR}/env" ]]; then
+  info "${CONF_DIR}/env already exists — not overwritten."
+else
+  info "Creating initial ${CONF_DIR}/env from template..."
+  cp "${CONF_DIR}/env.example" "${CONF_DIR}/env"
+  chmod 600 "${CONF_DIR}/env"
+fi
+
+# Systemd unit
+info "Installing systemd unit to ${UNIT_PATH}..."
+cat > "${UNIT_PATH}" <<'EOF'
+[Unit]
+Description=Bambu Observer — printer monitoring and filament tracking
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=bambu-observer
+EnvironmentFile=/etc/bambu-observer/env
+ExecStart=/usr/local/bin/bambu-observer
+Restart=on-failure
+RestartSec=5s
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+systemctl daemon-reload
+systemctl enable --now bambu-observer
+info "Service enabled and started."
+
+echo ""
+info "Installation complete."
+info "Edit ${CONF_DIR}/env with your printer credentials, then run:"
+info "  systemctl restart bambu-observer"

--- a/packaging/bambu-observer.service
+++ b/packaging/bambu-observer.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Bambu Observer — printer monitoring and filament tracking
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=bambu-observer
+EnvironmentFile=/etc/bambu-observer/env
+ExecStart=/usr/local/bin/bambu-observer
+Restart=on-failure
+RestartSec=5s
+
+[Install]
+WantedBy=multi-user.target

--- a/packaging/env.example
+++ b/packaging/env.example
@@ -1,0 +1,36 @@
+# /etc/bambu-observer/env
+# Bambu Observer configuration.
+# Restart the service after any change: systemctl restart bambu-observer
+
+# ── Required ──────────────────────────────────────────────────────────────────
+
+# Local IP address of the printer
+PRINTER_IP=192.168.1.100
+
+# Printer serial number (on the printer label or in the Bambu app)
+PRINTER_SERIAL=01P00A000000001
+
+# 8-digit access code shown on the printer screen (Settings → LAN Mode)
+PRINTER_ACCESS_CODE=12345678
+
+# ── Optional ──────────────────────────────────────────────────────────────────
+
+# Log verbosity. DEBUG for verbose output; default is INFO.
+#LOG_LEVEL=INFO
+
+# Base URL of a Spoolman instance — enables automatic spool-usage updates.
+#SPOOLMAN_URL=http://192.168.1.10:7912
+
+# Ordered list of spool ID sources tried left-to-right.
+# "api" = active spool set via the web UI; "notes" = spoolman#N tag in filament notes.
+# Default: api,notes
+#SPOOLMAN_SOURCE=api,notes
+
+# Address to bind the built-in HTTP server — enables active spool tracking.
+#WEBUI_ADDR=:8080
+
+# Externally reachable base URL of the HTTP server — baked into generated QR codes.
+#WEBUI_BASE_URL=http://192.168.1.10:8080
+
+# Filesystem path for the audit log SQLite database.
+#AUDIT_DB_PATH=/var/lib/bambu-observer/audit.db


### PR DESCRIPTION
Closes #19

## What this adds

- **`install.sh`** — one-line install/upgrade script; self-contained, no `gh` CLI or `jq` required
- **`packaging/bambu-observer.service`** — systemd unit template (reference copy; script embeds it as a heredoc)
- **`packaging/env.example`** — all env vars; required three uncommented, optional ones commented with example values

## How it works

**Install** resolves the latest tag via the GitHub releases API (`grep`/`sed`, no `jq`), downloads the architecture-matched binary and `sha256sums.txt`, verifies the checksum, creates the `bambu-observer` system user, installs the binary, drops `env.example`, copies it to `env` only if `env` does not already exist (conffile semantics), installs the systemd unit, and runs `daemon-reload && enable --now`.

**Upgrade** (`--upgrade`) stops the service, swaps the binary, and starts the service again — `env` is never touched.

Both paths are idempotent.

---

## How to test on a live Linux machine

> Requires a Linux host (amd64 or arm64) with `curl`, `sha256sum`, `useradd`, and `systemctl`. A Debian/Ubuntu VM or a Raspberry Pi works well.

### 1. Prerequisite — publish a non-draft release

The script uses `/releases/latest` which only returns non-draft, non-prerelease releases. Promote `v0.1.0-rc.1` from draft, or push a real `v0.1.0` tag to trigger the release pipeline first.

### 2. Fresh install

```bash
# Download and inspect before running (recommended)
curl -fsSL https://raw.githubusercontent.com/szymon3/bambu-middleman/feat/install-script/install.sh -o install.sh
less install.sh
sudo bash install.sh
```

**Expected outcome:**
- System user `bambu-observer` created (`id bambu-observer` confirms)
- Binary installed: `bambu-observer --version` prints the release tag
- Config dir exists: `ls /etc/bambu-observer/` shows `env` and `env.example`
- Service enabled and running (will fail to connect until `env` is filled in — that is expected):

```bash
systemctl status bambu-observer
journalctl -u bambu-observer -n 20
```

### 3. Fill in credentials and verify the service starts cleanly

```bash
sudo nano /etc/bambu-observer/env   # set PRINTER_IP, PRINTER_SERIAL, PRINTER_ACCESS_CODE
sudo systemctl restart bambu-observer
sudo journalctl -u bambu-observer -f
```

### 4. Idempotency — re-run install, confirm `env` is not clobbered

```bash
# Add a marker so we can verify it survives
sudo bash -c 'echo "# idempotency-marker" >> /etc/bambu-observer/env'

sudo bash install.sh

grep idempotency-marker /etc/bambu-observer/env   # must still be there
```

### 5. Upgrade path

```bash
sudo bash install.sh --upgrade
```

**Expected outcome:**
- Service stops, new binary lands, service restarts
- `journalctl -u bambu-observer -n 5` shows a clean restart
- `/etc/bambu-observer/env` unchanged (verify the marker from step 4 is still present)

### 6. Architecture check (arm64)

If testing on a Raspberry Pi or arm64 VM:

```bash
uname -m          # should print aarch64
bambu-observer --version   # should match the release tag
```
